### PR TITLE
Change o field of Expectation from js.Ojbect to *js.Object

### DIFF
--- a/expectation.go
+++ b/expectation.go
@@ -3,7 +3,7 @@ package jasmine
 import "github.com/gopherjs/gopherjs/js"
 
 type Expectation struct {
-	o   js.Object
+	o   *js.Object
 	Not *Expectation `js:"not"`
 }
 


### PR DESCRIPTION
In the latest version of gopherjs, [Call](https://godoc.org/github.com/gopherjs/gopherjs/js#Object.Call) returns a pointer to js.Object.
